### PR TITLE
[JENKINS-55562] - Apply workaround in the version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>2.2.0</compatibleSinceVersion>
-                    <minimumJavaVersion>8</minimumJavaVersion>
+                    <minimumJavaVersion>1.8</minimumJavaVersion>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-55562 . Starting from 2.158 the plugin installations will fail, because Jenkins core does not properly process the JEP-233 version numbers in https://github.com/jenkinsci/jenkins/pull/3016 .

The update just fixes the default behavior, ideally the plugin definition should append the Maven HPI plugin configuration instead of overriding the version

@jenkinsci/java11-support 
