### PR TITLE
[JENKINS-55562] Omit minimumJavaVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>2.2.0</compatibleSinceVersion>
-                    <minimumJavaVersion>8</minimumJavaVersion>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Alternative to @oleg-nenashev’s #5. Produces the right manifests:

```manifest
Compatible-Since-Version: 2.2.0
Minimum-Java-Version: 1.8
```

`-X` shows effective configuration to be

```xml
<?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <classesDirectory default-value="${project.build.outputDirectory}"/>
  <compatibleSinceVersion>2.2.0</compatibleSinceVersion>
  <containerConfigXML default-value="${maven.war.containerConfigXML}"/>
  <dependentWarIncludes default-value="**"/>
  <failOnVersionOverrideToDifferentRelease default-value="true"/>
  <filters default-value="${project.build.filters}"/>
  <hpiName default-value="${project.build.finalName}"/>
  <localRepository default-value="${localRepository}"/>
  <minimumJavaVersion>1.8</minimumJavaVersion>
  <outputDirectory default-value="${project.build.directory}"/>
  <pluginName default-value="${project.name}"/>
  <pluginVersionDescription default-value="${plugin.version.description}"/>
  <remoteRepos default-value="${project.remoteArtifactRepositories}"/>
  <warSourceDirectory default-value="${basedir}/src/main/webapp"/>
  <warSourceIncludes default-value="**"/>
  <webappDirectory default-value="${project.build.directory}/${project.build.finalName}"/>
  <workDirectory default-value="${project.build.directory}/war/work"/>
  <project default-value="${project}"/>
</configuration>
```

as expected. No need for `combine.children="append"`; that is for more exotic use cases. Fixes @rpionke’s https://github.com/jenkinsci/performance-signature-dynatrace-plugin/commit/fa5c038e838629a5e3949989620629a93e0f1dd9.