### PR TITLE
[Java 11] Bump to upcoming fixed JAXB API plugin

### DIFF
--- a/dynatrace-appmon/pom.xml
+++ b/dynatrace-appmon/pom.xml
@@ -41,6 +41,12 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jaxb</artifactId>
             <version>${retrofit-version}</version>
+            <exclusions>
+                <exclusion> <!-- Use the one from the Jenkins JAXB Api plugin -->
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>

--- a/dynatrace/pom.xml
+++ b/dynatrace/pom.xml
@@ -41,6 +41,12 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jaxb</artifactId>
             <version>${retrofit-version}</version>
+            <exclusions>
+                <exclusion> <!-- Use the one from the Jenkins JAXB Api plugin -->
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.2.11</version>
+            <version>2.3.x-20190131.120627-1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.3.x-20190131.120627-1</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
[JENKINS-55202](https://issues.jenkins-ci.org/browse/JENKINS-55202)

2.2.11 had a dependency using `systemPath`, which was causing issues on Java 11.

Using here a timestamped SNAPSHOT from https://github.com/jenkinsci/jaxb-plugin/pull/6

@rpionke 
cc @jenkinsci/java11-support 