### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
         [platform: 'linux', jdk: '8'],
-        [platform: 'windows', jdk: '8', javaLevel: '8'],
-        [platform: 'linux', jdk: '11', javaLevel: '8']
+        [platform: 'windows', jdk: '8'],
+        [platform: 'linux', jdk: '11']
 ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.